### PR TITLE
remove values that conflict with app manifest

### DIFF
--- a/glide-bitmap-pool/src/main/AndroidManifest.xml
+++ b/glide-bitmap-pool/src/main/AndroidManifest.xml
@@ -15,11 +15,6 @@
   ~    limitations under the License.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.glidebitmappool">
-
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
+<manifest package="com.glidebitmappool">
 
 </manifest>


### PR DESCRIPTION
Removes the unnecessary values from the manifest. Keys like allowBackup should be set at the application level instead.