### PR TITLE
Fixing returning null bitmap by reiteration of stream actions

### DIFF
--- a/glide-bitmap-pool/src/main/java/com/glidebitmappool/GlideBitmapFactory.java
+++ b/glide-bitmap-pool/src/main/java/com/glidebitmappool/GlideBitmapFactory.java
@@ -27,6 +27,7 @@ import android.util.TypedValue;
 import com.glidebitmappool.internal.Util;
 
 import java.io.FileDescriptor;
+import java.io.IOException;
 import java.io.InputStream;
 
 /**


### PR DESCRIPTION
After decoding a stream there was errors of further decoding stream calls because the reading position of a stream was not reseted.

Added function "rewindStream" which safely reset stream for further usage.